### PR TITLE
Ansible Service Module doesn't work

### DIFF
--- a/provisioning/roles/keystone/tasks/Debian.yml
+++ b/provisioning/roles/keystone/tasks/Debian.yml
@@ -50,6 +50,7 @@
 - name: wait for keystone to come back up
   wait_for: 
     port: "{{keystone_endpoint_port}}"
+    host: "{{ansible_host}}"
 
 - name: add keystone service
   keystone_service: 

--- a/provisioning/roles/keystone/tasks/Debian.yml
+++ b/provisioning/roles/keystone/tasks/Debian.yml
@@ -43,14 +43,13 @@
 - name: ensure services are started
   service: 
     name: "{{ item }}"
-    state: started 
+    state: restarted 
   with_items: "{{ debian_services }}"
 
 # keystone seems to take a while...
 - name: wait for keystone to come back up
   wait_for: 
     port: "{{keystone_endpoint_port}}"
-    host: "{{ansible_host}}"
 
 - name: add keystone service
   keystone_service: 

--- a/provisioning/roles/keystone/tasks/Debian.yml
+++ b/provisioning/roles/keystone/tasks/Debian.yml
@@ -41,9 +41,7 @@
   command: /usr/bin/keystone-manage db_sync
 
 - name: ensure services are started
-  service: 
-    name: "{{ item }}"
-    state: restarted 
+  shell: service "{{ item }}" start
   with_items: "{{ debian_services }}"
 
 # keystone seems to take a while...


### PR DESCRIPTION
For some reason, the Ansible "service" module doesn't work within a docker container.
Instead, I explicitly use the
           service "{{ item }}" start
shell command.
Doron
